### PR TITLE
filter out :@computed_region

### DIFF
--- a/repr_llm/pandas.py
+++ b/repr_llm/pandas.py
@@ -52,9 +52,15 @@ def summarize_dataframe(df, sample_rows=5, sample_columns=20):
     else:
         categorical_summary = pd.DataFrame(columns=['Column Name'])
 
-    sample_columns = min(sample_columns, df.shape[1])
+    # Ignore any columns that do not have `:@computed_region` in the name, which are derived data not useful for
+    # summarization of sample data
+    filtered_columns = [col for col in df.columns if ":@computed_region" not in col]
+
+    # adjust sample size with filtered dataframe shape
+    sample_columns = min(sample_columns, len(filtered_columns))
     sample_rows = min(sample_rows, df.shape[0])
-    sampled = df.sample(sample_columns, axis=1).sample(sample_rows, axis=0)
+
+    sampled = df[filtered_columns].sample(sample_columns, axis=1).sample(sample_rows, axis=0)
 
     tablefmt = "github"
 


### PR DESCRIPTION
A lot of public datasets have these computed regions. To make LLM summarized output more readable for humans, let's not include it in the sampling.

![image](https://github.com/rgbkrk/repr_llm/assets/836375/6cbd15f5-c064-4dfe-aacb-e6e5ee4b25f6)

The columns will still appear in the dtypes summary.